### PR TITLE
CLI option '--outfile' to save the output of the command

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -35,6 +35,7 @@
 - **`--no-color (-n)`**: Disable ANSI color output
 - **`--force (-f)`**: Removes checks and prompts before `config.xml` or `configctl` are touched.
 - **`--verbose (-v)`**: Sets verbosity (1=error, 2=warning, 3=info, 4=note, 5=debug).
+- **`--outfile (-o)`**: Save output of the command into a specified file
 - **`--no-color (-n)`**: Removes ANSI colors from the printout.
 - **`--xml (-x)`**: Displays results in XML format.
 - **`--json (-j)`**: Displays results in JSON format.

--- a/README.MD
+++ b/README.MD
@@ -16,12 +16,9 @@
 - **`set <xpath> [value] [(attribute)]`**: Adds a new branch, value and/or attribute
 - **`set <xpath> [value] [(attribute)] -d`**: Deletes branch, value and/or attribute
 - **`discard [<xpath>]`**: Discards a value (or all changes) in the 'staging.xml'
-
 - **`commit`**: Moves staging.xml to active 'config.xml'
-
 - **`export [<source.xml>] [<target.xml>]`**: Extracts a patch file
 - **`import [patch.xml]`**: Reads provided XML patch and injects it into 'staging.xml'
-
 - **`backup [<backup.xml>]`**: Lists available backup configs or displays a specific backup
 - **`restore [<backup.xml>]`**: Restores config.xml from a specific backup.xml. (alias: `load`)
 - **`save [<file.xml>]`**: Creates a new /conf/backup/file.xml
@@ -29,10 +26,8 @@
 - **`delete age [days]`**: Deletes all backups older than specified days
 - **`delete keep [count]`**: Keeps specified number of backups and deletes the rest
 - **`delete trim [count]`**: Deletes number of the oldest backups
-
 - **`sysinfo [<xpath>]`**: Retrieves system information from the firewall
 - **`run <service> <command>`**: Executes commands on OPNsense.
-
 
 ### Flags
 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -34,7 +34,7 @@ var compareCmd = &cobra.Command{
   opnsense compare                Compare differences from 'config.xml' to 'staging.xml'`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.SetFlags(verbose, force, host, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
+		internal.SetFlags(verbose, force, host, outfile, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
 		var oldconfig, newconfig, path string
 
 		switch len(args) {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -33,7 +33,7 @@ var exportCmd = &cobra.Command{
   opnsense export                Exports XML patch from 'config.xml' to 'staging.xml'`,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		internal.SetFlags(verbose, force, host, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
+		internal.SetFlags(verbose, force, host, outfile, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
 		var oldconfig, newconfig, path string
 
 		switch len(args) {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -36,7 +36,7 @@ Once the patch is imported, it is added to currently staged changes in 'staging.
 		if !cmd.Flag("depth").Changed {
 			depth = 5
 		}
-		internal.SetFlags(verbose, force, host, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
+		internal.SetFlags(verbose, force, host, outfile, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
 
 		patchdoc := etree.NewDocument()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ var (
 	host        string
 	configfile  string
 	stagingfile string
+	outfile     string
 	nocolor     bool
 	depth       int = 1
 	xmlFlag     bool
@@ -40,6 +41,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&host, "target", "t", "", "Specify target host (user@hostname[:port])")
+	rootCmd.PersistentFlags().StringVarP(&outfile, "outfile", "o", "", "Save output of the command into a specified file")
 	rootCmd.PersistentFlags().IntVarP(&verbose, "verbose", "v", 1, "Set verbosity level (range: 1-5, default: 1)")
 	rootCmd.PersistentFlags().BoolVarP(&nocolor, "no-color", "n", false, "Disable ANSI color output")
 	rootCmd.PersistentFlags().BoolVarP(&xmlFlag, "xml", "x", false, "Output results in XML format")
@@ -52,7 +54,7 @@ func init() {
 	cobra.OnInitialize(func() {
 		configfile = "/conf/config.xml"
 		stagingfile = "/conf/staging.xml"
-		internal.SetFlags(verbose, force, host, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
+		internal.SetFlags(verbose, force, host, outfile, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
 		//other initializations
 	})
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -59,7 +59,6 @@ var showCmd = &cobra.Command{
 
 		deltadoc := internal.DiffXML(configdoc, stagingdoc, true)
 		internal.PrintDocument(deltadoc, path)
-
 	},
 }
 

--- a/cmd/sysinfo.go
+++ b/cmd/sysinfo.go
@@ -36,7 +36,7 @@ var sysinfoCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if changed := cmd.Flags().Changed("depth"); !changed {
 			depth = 2
-			internal.SetFlags(verbose, force, host, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
+			internal.SetFlags(verbose, force, host, outfile, configfile, nocolor, depth, xmlFlag, yamlFlag, jsonFlag)
 		}
 
 		path := "system"

--- a/internal/PrintDocument.go
+++ b/internal/PrintDocument.go
@@ -17,6 +17,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/beevik/etree"
 )
@@ -33,5 +34,16 @@ func PrintDocument(doc *etree.Document, path string) {
 	default:
 		output = ConfigToTTY(doc, path)
 	}
-	fmt.Println(output)
+
+	if len(outfile) > 0 {
+		f, err := os.Create(outfile)
+
+		if err != nil {
+			Log(1, "%v", err)
+		}
+
+		fmt.Fprintln(f, output)
+	} else {
+		fmt.Println(output)
+	}
 }

--- a/internal/setflags.go
+++ b/internal/setflags.go
@@ -20,6 +20,7 @@ var (
 	force      bool
 	host       string
 	configfile string
+	outfile    string
 	nocolor    bool
 	depth      int
 	xmlFlag    bool
@@ -27,13 +28,14 @@ var (
 	jsonFlag   bool
 )
 
-func SetFlags(v int, f bool, h string, config string, nc bool, dpt int, x bool, y bool, j bool) {
+func SetFlags(v int, f bool, h string, of string, config string, nc bool, dpt int, x bool, y bool, j bool) {
 	if v < 1 || v > 5 {
 		Log(1, "invalid verbosity level %d. It should be between 1 and 5", v)
 	}
 	verbose = v
 	force = f
 	host = h
+	outfile = of
 	configfile = config
 	nocolor = nc
 	depth = dpt


### PR DESCRIPTION
Hello!
I've added '--outfile' CLI option to save the command output into the files for the later processing - for example, using **jq**.
Thanks!